### PR TITLE
bump rtt-target to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ description = "An rtt-target logger implementation for Cortex-M embedded platfor
 
 [dependencies]
 log = "0.4.11"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = {version = "0.3.1", features = ["cortex-m"] }


### PR DESCRIPTION
Using `rtt-target = 0.3` with current `rtt-logger` that depends on an older `rtt-target = 0.2.0` doesn't work. Log messages aren't shown.
This bumps the `rtt-target` dependency in `rtt-logger`.
It would be great to also get a release for this.