### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Bob McWhirter <bmcwhirt@redhat.com>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "An rtt-target logger implementation for Cortex-M embedded platforms"
+repository = "https://github.com/drogue-iot/rtt-logger"
 
 
 [dependencies]


### PR DESCRIPTION
It's a bit tricky to find this repo since it doesn't link on docs.rs or crates.io. This should update that.